### PR TITLE
Set up testing tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,29 @@ Here are some steps to open a pull request:
 1. Claim an issue by commenting on it (if one doesn't exist, open one).
 2. Fork and clone the repo.
 3. Run `bin/setup`.
-4. Run the specs and make sure everything passes.
-   - `bin/rspec` will use spring
-   - `bundle exec rake spec` won't use spring and will report test coverage
-   - `bundle exec guard` will watch for file modifications and run corresponding specs
+4. Run the specs and make sure everything passes (see below).
 5. Add one or more specs for your changes.
 6. Make your changes.
 7. Make sure your specs pass and that RuboCop doesn't report any new issues.
 8. Push to your fork and submit a pull request. Include the issue number in the PR description (e.g. "Resolves #19").
 
 Once you've submitted a PR, Heroku will create a review app with your code which you can access at https://greensteps-pr-###.herokuapp.com/ (replace ### with your PR number).
+
+## Running Specs
+
+We've set up two main ways to run specs...
+
+### During Development
+
+1. Use `bundle exec guard` to have specs automatically run when changes are saved
+2. Use `bin/rspec` followed by command line arguments to run RSpec on demand (you can run it for just specific files or folders, and give it other [command line options](https://relishapp.com/rspec/rspec-core/docs/command-line))
+
+Both of the above commands will run the specs using Spring. This makes it faster to run specs because the Rails environment doesn't have to be loaded each time, but can give an inacurrate test coverage, so that won't be calculated when Spring is running.
+
+### Before Committing, Pushing Changes, Submitting a PR, etc.
+
+`bundle exec rake` will do the following:
+
+1. Run RuboCop with autocorrections turned on
+2. Run the full spec suite without Spring and will calculate test coverage
+3. Perform a local CodeClimate analysis if you have docker installed and the CodeClimate image downloaded

--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,7 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+Rake::Task[:default].clear
+
+task default: ['lint:rubocop:autocorrect', :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,4 @@ Rails.application.load_tasks
 
 Rake::Task[:default].clear
 
-task default: ['lint:rubocop:autocorrect', :spec]
+task default: ['lint:rubocop:autocorrect', 'lint:factory_girl', :spec]

--- a/Rakefile
+++ b/Rakefile
@@ -8,4 +8,9 @@ Rails.application.load_tasks
 
 Rake::Task[:default].clear
 
-task default: ['lint:rubocop:autocorrect', 'lint:factory_girl', :spec]
+task default: [
+  'lint:rubocop:autocorrect',
+  'lint:factory_girl',
+  :spec,
+  'lint:codeclimate'
+]

--- a/lib/code_climate_cli.rb
+++ b/lib/code_climate_cli.rb
@@ -1,0 +1,33 @@
+require 'mkmf'
+
+module CodeClimateCli
+  def self.available?
+    find_executable('docker') &&
+      system('docker image inspect codeclimate/codeclimate', out: File::NULL)
+  end
+
+  def self.run(command)
+    system(<<~SHELL)
+      docker run \
+        --interactive --tty --rm \
+        --env CODECLIMATE_CODE="$PWD" \
+        --volume "$PWD":/code \
+        --volume /var/run/docker.sock:/var/run/docker.sock \
+        --volume /tmp/cc:/tmp/cc \
+        codeclimate/codeclimate #{command}
+    SHELL
+  end
+
+  # rubocop:disable Rails/Output
+  def self.give_install_instructions
+    puts <<~TEXT
+      A local CodeClimate analysis wasn't performed because the docker image
+      wasn't available. Instructions for installing CodeClimate CLI can be
+      found here:
+
+        https://github.com/codeclimate/codeclimate
+
+    TEXT
+  end
+  # rubocop:enable Rails/Output
+end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,12 @@
+require Rails.root.join('lib', 'code_climate_cli.rb').to_s
+
+namespace :lint do
+  desc 'Runs codeclimate cli if it is available'
+  task :codeclimate do
+    if CodeClimateCli.available?
+      CodeClimateCli.run('analyze')
+    else
+      CodeClimateCli.give_install_instructions
+    end
+  end
+end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -9,4 +9,12 @@ namespace :lint do
       CodeClimateCli.give_install_instructions
     end
   end
+
+  namespace :rubocop do
+    task :autocorrect do
+      puts "\n"
+      system 'rubocop --auto-correct'
+      puts "\n"
+    end
+  end
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -11,6 +11,7 @@ namespace :lint do
   end
 
   namespace :rubocop do
+    desc 'Runs rubocop with autocorrections turned on'
     task :autocorrect do
       puts "\n"
       system 'rubocop --auto-correct'

--- a/lib/tasks/lint/codeclimate.rake
+++ b/lib/tasks/lint/codeclimate.rake
@@ -9,13 +9,4 @@ namespace :lint do
       CodeClimateCli.give_install_instructions
     end
   end
-
-  namespace :rubocop do
-    desc 'Runs rubocop with autocorrections turned on'
-    task :autocorrect do
-      puts "\n"
-      system 'rubocop --auto-correct'
-      puts "\n"
-    end
-  end
 end

--- a/lib/tasks/lint/factory_girl.rake
+++ b/lib/tasks/lint/factory_girl.rake
@@ -1,0 +1,15 @@
+namespace :lint do
+  desc 'Verify that all Factory Girl factories are valid'
+  task factory_girl: :environment do
+    if Rails.env.test?
+      begin
+        DatabaseCleaner.start
+        FactoryGirl.lint
+      ensure
+        DatabaseCleaner.clean
+      end
+    else
+      system("bundle exec rake factory_girl:lint RAILS_ENV='test'")
+    end
+  end
+end

--- a/lib/tasks/lint/rubocop.rake
+++ b/lib/tasks/lint/rubocop.rake
@@ -1,0 +1,10 @@
+namespace :lint do
+  namespace :rubocop do
+    desc 'Runs rubocop with autocorrections turned on'
+    task :autocorrect do
+      puts "\n"
+      system 'rubocop --auto-correct'
+      puts "\n"
+    end
+  end
+end

--- a/mkmf.log
+++ b/mkmf.log
@@ -1,4 +1,4 @@
-find_executable: checking for phantomjs... -------------------- yes
+find_executable: checking for docker... -------------------- yes
 
 --------------------
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,11 +22,6 @@ WebMock.disable_net_connect!(allow_localhost: true)
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.after(:suite) do
-    puts "\n\n"
-    system 'rubocop --auto-correct'
-  end
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/tasks/lint/code_climate_spec.rb
+++ b/spec/tasks/lint/code_climate_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'rake lint:codeclimate', type: :task do
+  it 'prints install instructions when the CodeClimate CLI is not available' do
+    allow(CodeClimateCli).to receive(:available?).and_return(false)
+    expect(CodeClimateCli).to receive(:give_install_instructions)
+
+    task.execute
+  end
+
+  it 'performs a local CodeClimate analysis when the CLI is available' do
+    allow(CodeClimateCli).to receive(:available?).and_return(true)
+    expect(CodeClimateCli).to receive(:run).with('analyze')
+
+    task.execute
+  end
+end


### PR DESCRIPTION
- default rake task runs linters (rubocop with auto corrections, factory girl lint, Code Climate analysis) and specs
- `spec` rake task and `bin/rspec` will only run specs now

closes #6 #10 #11 