### PR TITLE
Fix Issue#1 by adding an explicit move to root path.

### DIFF
--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -24,13 +24,12 @@ RSpec.describe 'Navigation' do
 
   scenario 'User clicks the browser back button and then tries to open the '\
            'navigation drawer', :js do
-    skip 'This test is flaky, but the functionality works... from what I can'\
-         'tell. Need to fix. I think it is a timing thing?'
     create_and_login_user
+    visit root_path
 
     appbar.open_drawer
     nav_drawer.edit_account_settings
-    click_browser_back_button
+    go_back
     wait_for '.welcome.index'
     appbar.open_drawer
 

--- a/spec/support/browser_helpers.rb
+++ b/spec/support/browser_helpers.rb
@@ -1,9 +1,0 @@
-module BrowserHelpers
-  def click_browser_back_button
-    page.evaluate_script('window.history.back()')
-  end
-end
-
-RSpec.configure do |config|
-  config.include BrowserHelpers, type: :feature
-end


### PR DESCRIPTION
Fixes #1

---

Adds an explicit move to the root path to add it to the Capybara session history and then use Capybara to go back in history when needed. Since we're relying on Capybara to go back, no need for BrowserHelper module so it was removed.