### PR TITLE
Remove factory_girl lint task from default rake task pre-spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 
 task default: [
   'lint:rubocop:autocorrect',
-  'lint:factory_girl',
   :spec,
   'lint:codeclimate'
 ]

--- a/spec/lint_spec.rb
+++ b/spec/lint_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe 'Lint' do
+  it 'FactoryGirl' do
+    FactoryGirl.lint
+  end
+end


### PR DESCRIPTION
Cool project!

This PR fixes #29 by not attempting to lint factory_girl factories before spec has had a chance to "maintain_test_schema!"

Took a bit to figure out what was going on. Rake was attempting to lint the factory girl factories before spec ran, which is what would load schema into the test database. The missing tables caused the factories to be "invalid".

Now, factory_girl lint will run as a spec itself, as suggested [here](https://github.com/thoughtbot/factory_girl/commit/7f31ba9239fcad8e2fbbf19c84d6dd516e37dab5).