### PR TITLE
Move gems listed at bottom to appropriate category

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,76 +6,47 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.0.4'
-# Use postgresql as the database for Active Record
-gem 'pg', '~> 0.18'
-# Use Puma as the app server
-gem 'puma', '~> 3.0'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
+gem 'bitters'
+gem 'bourbon'
 gem 'coffee-rails', '~> 4.2'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
-# Use jquery as the JavaScript library
-gem 'jquery-rails'
-# Turbolinks makes navigating your web application faster. Read more:
-# https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
+gem 'decent_exposure'
+gem 'devise'
+gem 'factory_girl_rails'
+gem 'faker'
+gem 'font-awesome-rails'
+gem 'haml-rails'
 gem 'jbuilder', '~> 2.5'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 3.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
+gem 'jquery-rails'
+gem 'jquery-ui-rails'
+gem 'pg', '~> 0.18'
+gem 'puma', '~> 3.0'
+gem 'rails', '~> 5.0.4'
+gem 'record_tag_helper'
+gem 'sass-rails', '~> 5.0'
+gem 'turbolinks', '~> 5'
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'uglifier', '>= 1.3.0'
 
 group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger
-  # console
   gem 'byebug', platform: :mri
+  gem 'capybara'
+  gem 'database_cleaner'
+  gem 'launchy'
+  gem 'poltergeist'
+  gem 'rails-controller-testing'
+  gem 'rspec-rails', '~> 3.6'
+  gem 'rubocop', '~> 0.49.1', require: false
+  gem 'shoulda-matchers'
+  gem 'simplecov', require: false
+  gem 'spring-commands-rspec'
+  gem 'webmock'
 end
 
 group :development do
-  # Access an IRB console on exception pages or by using <%= console %> anywhere
-  # in the code.
+  gem 'guard-rspec', require: false
   gem 'listen', '~> 3.0.5'
-  gem 'web-console', '>= 3.3.0'
-  # Spring speeds up development by keeping your application running in the
-  # background. Read more: https://github.com/rails/spring
+  gem 'pry'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console', '>= 3.3.0'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-gem 'bitters'
-gem 'bourbon'
-gem 'capybara', group: %i[development test]
-gem 'database_cleaner', group: :test
-gem 'decent_exposure'
-gem 'devise'
-gem 'factory_girl_rails' # need in production b/c use for sample data in staging
-gem 'faker' # ditto above
-gem 'font-awesome-rails'
-gem 'guard-rspec', require: false, group: :development
-gem 'haml-rails'
-gem 'jquery-ui-rails'
-gem 'launchy', group: :test
-gem 'poltergeist', group: :test
-gem 'pry'
-gem 'rails-controller-testing', group: :test
-gem 'record_tag_helper'
-gem 'rspec-rails', '~> 3.6', group: %i[development test]
-gem 'rubocop', '~> 0.49.1', require: false, group: %i[development test]
-gem 'shoulda-matchers', group: :test
-gem 'simplecov', require: false, group: :test
-gem 'spring-commands-rspec', group: :test
-gem 'webmock', group: :test


### PR DESCRIPTION
Resolves #60 

Removed unnecessary comments, unused gems, and group indication once it was moved to the correct category. Bin/rake was run to alphabetize gems once they were moved to the correct category.