### PR TITLE
Revoke admin privileges

### DIFF
--- a/app/assets/stylesheets/pages/admins/_admins.scss
+++ b/app/assets/stylesheets/pages/admins/_admins.scss
@@ -1,7 +1,29 @@
 .admins-admins {
   &.new, &.create {
-    max-width: 720px;
-    margin-left: auto;
-    margin-right: auto;
+    @media (screen and min-width: $medium-screen) {
+      max-width: 30em;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  &.index {
+    .admins {
+      margin-bottom: $base-spacing;
+
+      li:not(last-child) {
+        margin-bottom: $tiny-spacing;
+      }
+    }
+
+    .delete_admin {
+      @include button;
+      @include compact-button;
+      margin-right: $small-spacing;
+    }
+
+    .new_admin {
+      @include button;
+    }
   }
 }

--- a/app/controllers/admins/admins_controller.rb
+++ b/app/controllers/admins/admins_controller.rb
@@ -15,6 +15,11 @@ module Admins
       end
     end
 
+    def destroy
+      admin.demote
+      flash.now.notice = t('.success')
+    end
+
     private
 
     def admin_params

--- a/app/controllers/admins/base_controller.rb
+++ b/app/controllers/admins/base_controller.rb
@@ -6,16 +6,14 @@ module Admins
 
     def ensure_admin
       return if current_user.has_role? :admin
+
       respond_to do |format|
         format.html do
-          redirect_back(
-            fallback_location: root_path,
-            alert: t('restricted_to_admins')
-          )
+          redirect_back fallback_location: root_path, alert: t('admins_only')
         end
 
         format.js do
-          flash.now.alert = t('restricted_to_admins')
+          flash.now.alert = t('admins_only')
           render 'shared/update_flash', status: :unauthorized
         end
       end

--- a/app/controllers/admins/base_controller.rb
+++ b/app/controllers/admins/base_controller.rb
@@ -6,10 +6,19 @@ module Admins
 
     def ensure_admin
       return if current_user.has_role? :admin
-      redirect_back(
-        fallback_location: root_path,
-        alert: t('restricted_to_admins')
-      )
+      respond_to do |format|
+        format.html do
+          redirect_back(
+            fallback_location: root_path,
+            alert: t('restricted_to_admins')
+          )
+        end
+
+        format.js do
+          flash.now.alert = t('restricted_to_admins')
+          render 'shared/update_flash', status: :unauthorized
+        end
+      end
     end
   end
 end

--- a/app/forms/admin.rb
+++ b/app/forms/admin.rb
@@ -9,6 +9,21 @@ class Admin < ApplicationForm
     end
   end
 
+  def demote
+    user.remove_role :admin
+  end
+
+  def self.find(*args)
+    new.tap do |admin|
+      admin.user = User.with_role(:admin).find(*args)
+    end
+  end
+
+  def user=(user)
+    @user = user
+    @email = user.email
+  end
+
   private
 
   def user

--- a/app/forms/admin.rb
+++ b/app/forms/admin.rb
@@ -19,6 +19,7 @@ class Admin < ApplicationForm
     end
   end
 
+  # internal
   def user=(user)
     @user = user
     @email = user.email

--- a/app/views/admins/admins/destroy.js.erb
+++ b/app/views/admins/admins/destroy.js.erb
@@ -1,0 +1,2 @@
+$(".admins li:contains('<%= j(admin.email) %>')").remove()
+<%= render 'shared/update_flash' %>

--- a/app/views/admins/admins/index.html.erb
+++ b/app/views/admins/admins/index.html.erb
@@ -2,7 +2,12 @@
 
 <ul class="admins">
   <% admins.each do |admin| %>
-    <li><%= admin.email %></li>
+    <li>
+      <%= admin.email %>
+      <%= link_to admins_admin_path(admin), class: 'delete_admin', remote: true, method: :delete do %>
+        <%= fa_icon('minus') %>
+      <% end %>
+    </li>
   <% end %>
 </ul>
 

--- a/app/views/admins/admins/index.html.erb
+++ b/app/views/admins/admins/index.html.erb
@@ -3,10 +3,10 @@
 <ul class="admins">
   <% admins.each do |admin| %>
     <li>
-      <%= admin.email %>
       <%= link_to admins_admin_path(admin), class: 'delete_admin', remote: true, method: :delete do %>
         <%= fa_icon('minus') %>
       <% end %>
+      <%= admin.email %>
     </li>
   <% end %>
 </ul>

--- a/app/views/shared/update_flash.js.erb
+++ b/app/views/shared/update_flash.js.erb
@@ -1,0 +1,1 @@
+<%= render 'update_flash' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,7 +22,7 @@
 en:
   brand_name: "Brand Name"
   no_visitor_access: "Whoops, you must be signed in to do that."
-  restricted_to_admins: "You must be an admin to access that page."
+  admins_only: "You must be an admin to access that page."
   helpers:
     label:
       admin:

--- a/config/locales/views/admins/admins/en.yml
+++ b/config/locales/views/admins/admins/en.yml
@@ -7,3 +7,5 @@ en:
         header: "Grant Admin Privileges"
       create:
         success: "Admin privileges successfully granted!"
+      destroy:
+        success: "Admin privileges successfully revoked!"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   namespace :admins do
     get 'dashboards/show'
     resources 'prizes', only: [:new, :create]
-    resources 'admins', only: [:index, :new, :create]
+    resources 'admins', only: [:index, :new, :create, :destroy]
   end
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/controllers/admins/admins_controller_spec.rb
+++ b/spec/controllers/admins/admins_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admins::AdminsController, type: :controller do
-  it_should_behave_like 'an admin controller'
-
   describe 'POST #create' do
     context 'invalid admin' do
       it 're-renders the form' do
@@ -14,4 +12,13 @@ RSpec.describe Admins::AdminsController, type: :controller do
       end
     end
   end
+
+  context 'non-admin user' do
+    [
+      %i[get index],
+      %i[get new],
+      %i[post create]
+    ].each do |method, action|
+      include_examples 'restricted to admins html response', method, action
+    end
 end

--- a/spec/controllers/admins/admins_controller_spec.rb
+++ b/spec/controllers/admins/admins_controller_spec.rb
@@ -21,4 +21,9 @@ RSpec.describe Admins::AdminsController, type: :controller do
     ].each do |method, action|
       include_examples 'restricted to admins html response', method, action
     end
+
+    include_examples('restricted to admins ajax response', :delete, :destroy) do
+      let(:params) { { id: create(:admin) } }
+    end
+  end
 end

--- a/spec/controllers/admins/dashboards_controller_spec.rb
+++ b/spec/controllers/admins/dashboards_controller_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Admins::DashboardsController, type: :controller do
+  context 'non-admin user' do
+    include_examples 'restricted to admins html response', :get, :show
+  end
+end

--- a/spec/controllers/admins/prizes_controller_spec.rb
+++ b/spec/controllers/admins/prizes_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admins::PrizesController, type: :controller do
-  it_should_behave_like 'an admin controller'
-
   describe 'POST #create' do
     context 'invalid prize' do
       it 're-renders the form' do
@@ -12,6 +10,15 @@ RSpec.describe Admins::PrizesController, type: :controller do
 
         expect(response).to render_template(:new)
       end
+    end
+  end
+
+  context 'non-admin user' do
+    [
+      %i[get new],
+      %i[post create]
+    ].each do |method, action|
+      include_examples 'restricted to admins html response', method, action
     end
   end
 end

--- a/spec/features/admins/admins_spec.rb
+++ b/spec/features/admins/admins_spec.rb
@@ -23,4 +23,17 @@ RSpec.describe 'List of admins', type: :feature do
     expect(admin_list).to include admin_to_be
     expect(flash).to have_content t('admins.admins.create.success')
   end
+
+  scenario 'Admin revokes a user\'s admin privileges', :js do
+    create_and_login_admin
+    admin_to_loose_privileges = create :admin
+    visit admins_dashboards_show_path
+
+    admin_dashboard.manage_admins
+    admin_list.remove admin_to_loose_privileges
+    wait_for_ajax
+
+    expect(admin_list).to_not include admin_to_loose_privileges
+    expect(flash).to have_content t('admins.admins.destroy.success')
+  end
 end

--- a/spec/forms/admin_spec.rb
+++ b/spec/forms/admin_spec.rb
@@ -8,4 +8,36 @@ RSpec.describe Admin, type: :form do
 
     expect(admin).to be_invalid
   end
+
+  describe '#save' do
+    it 'grants the user the admin role' do
+      user = create :user
+      admin = Admin.new(email: user.email)
+
+      admin.save
+
+      expect(user).to have_role(:admin)
+    end
+  end
+
+  describe '#demote' do
+    it 'removes the admin role' do
+      user = create :admin
+      admin = Admin.new(email: user.email)
+
+      admin.demote
+
+      expect(user).to_not have_role(:admin)
+    end
+  end
+
+  describe '.find' do
+    it 'initializes a new admin object that is tied to the specified user' do
+      user = create :admin
+
+      admin = Admin.find(user.id)
+
+      expect(admin.email).to eq user.email
+    end
+  end
 end

--- a/spec/page_objects/admin_list.rb
+++ b/spec/page_objects/admin_list.rb
@@ -4,6 +4,10 @@ module PageObjects
       this.has_text? admin.email
     end
 
+    def remove(admin)
+      this.find('li', text: admin.email).find('.delete_admin').click
+    end
+
     def selector
       '.admins'
     end

--- a/spec/support/shared_examples/admin_controller.rb
+++ b/spec/support/shared_examples/admin_controller.rb
@@ -19,9 +19,20 @@ RSpec.shared_examples 'restricted to admins html response' do |method, action|
   end
 end
 
+RSpec.shared_examples 'restricted to admins ajax response' do |method, action|
+  before(:each) { sign_in create(:user) }
 
+  let(:params) {}
 
+  describe "#{method.to_s.upcase} ##{action} (XHR)" do
+    it 'gives a 401: Unauthorized response' do
+      send(method, action, params: params, xhr: true)
+      expect(response).to have_http_status :unauthorized
+    end
 
+    it 'flashes an alert message' do
+      send(method, action, params: params, xhr: true)
+      expect(flash[:alert]).to eq t('restricted_to_admins')
     end
   end
 end

--- a/spec/support/shared_examples/admin_controller.rb
+++ b/spec/support/shared_examples/admin_controller.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples 'restricted to admins html response' do |method, action|
 
     it 'flashes an alert message' do
       send(method, action, params: params)
-      expect(flash[:alert]).to eq t('restricted_to_admins')
+      expect(flash[:alert]).to eq t('admins_only')
     end
   end
 end
@@ -32,7 +32,7 @@ RSpec.shared_examples 'restricted to admins ajax response' do |method, action|
 
     it 'flashes an alert message' do
       send(method, action, params: params, xhr: true)
-      expect(flash[:alert]).to eq t('restricted_to_admins')
+      expect(flash[:alert]).to eq t('admins_only')
     end
   end
 end

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,0 +1,15 @@
+module WaitForAjax
+  def wait_for_ajax
+    Timeout.timeout(Capybara.default_max_wait_time) do
+      loop until finished_all_ajax_requests?
+    end
+  end
+
+  def finished_all_ajax_requests?
+    page.evaluate_script('jQuery.active').zero?
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjax, type: :feature
+end


### PR DESCRIPTION
## Description
Admins can revoke admin privileges using the minus button next to the person's email on the admin list.

## Developer Checklist
- [x] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [x] All specs and linters pass (including Code Climate)
- [x] I have followed the style of nearby code
- [x] The build on Semaphore is successful
- [x] I have added tests for my changes and these tests would fail without my
      changes.
- [x] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
- [x] I have [internationalized](http://guides.rubyonrails.org/i18n.html) my
      changes

## Maintainer Checklist
- [ ] Run migrations (if necessary) in production after deployment
- [ ] Review issues and update labels
