### PR TITLE
Automatically clear logs

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,1 +1,3 @@
+# settings specific to the dev environment go here
+
 USE_SAMPLE_DATA=true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# clear logs before specs run and when the development environment is initialized
+AUTO_CLEAR_LOGS=true

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
+# settings common to dev and test environments go here
+
 # clear logs before specs run and when the development environment is initialized
 AUTO_CLEAR_LOGS=true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Devise said to do this
-config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/config/initializers/clean_up.rb
+++ b/config/initializers/clean_up.rb
@@ -1,0 +1,5 @@
+# Delete old logs automatically when the server or console are started. For the
+# test environment, this is done in a before(:suite) hook.
+if Rails.env.development? && ENV.fetch('AUTO_CLEAR_LOGS')
+  `rake log:clear LOG=development`
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,10 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    `rake log:clear LOG=test` if ENV.fetch('AUTO_CLEAR_LOGS')
+  end
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
## Description

Automatically clear `test.log` before each RSpec run and whenever the development environment is initialized. This is opt-in, so you need to set the environment variable AUTO_CLEAR_LOGS to true for it to have an effect.

## Developer Checklist
*You can mark items off by replacing `[ ]` with `[x]` or in the rendered
markdown, you can simply check the checkbox.*
- [x] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [ ] All specs and linters pass (including Code Climate)
- [x] I have followed the style of nearby code
- [ ] The build on Semaphore is successful
- [x] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
