### PR TITLE
Configure Devise to use ActiveJob

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable,
          :confirmable
+
+  def send_devise_notification(mailer_method_name, *args)
+    devise_mailer.send(mailer_method_name, self, *args).deliver_later
+  end
 end

--- a/spec/features/users/registrations_spec.rb
+++ b/spec/features/users/registrations_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'User Registrations', type: :feature do
-  scenario 'Visitor signs up', :js do
+  scenario 'Visitor signs up', :js, :with_active_job_test_adapter do
     new_user_info = build_stubbed :user
 
     visit root_path
     sign_up_form.fill_and_submit_with new_user_info
 
     expect(page).to flash_message t('devise.registrations.signed_up')
+    expect(ActionMailer::DeliveryJob).to have_been_enqueued
     expect(User).to exist email: new_user_info.email
     expect(page).to_not show :sign_up_form
     expect(page).to_not show :log_in_form

--- a/spec/support/job_helpers.rb
+++ b/spec/support/job_helpers.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.around(:example, :with_active_job_test_adapter) do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    example.run
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+end


### PR DESCRIPTION
## Description

This PR overrides a method in the user model so that Devise will use ActiveJob to send emails.

Fixes #116 

## Developer Checklist
- [x] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [x] All specs and linters pass (including Code Climate)
- [x] I have followed the style of nearby code
- [x] The build on Semaphore is successful
- [x] I have added tests for my changes.
- [x] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
- [x] I have [internationalized](http://guides.rubyonrails.org/i18n.html) my
      changes
