### PR TITLE
To set log level, look to env variable first

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module Greensteps
       g.jbuilder false
     end
 
+    config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'debug')
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,10 +47,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
 

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -10,7 +10,12 @@ namespace :heroku do
     Rake::Task['after_party:run'].invoke
   end
 
-  desc 'Creates a local Heroku release (for local prod. env. testing)'
+  desc <<~TEXT
+    Creates a local Heroku release for local testing of the production
+    environment. Run this task with
+      heroku local:run rails heroku:local_release -e .env.production \
+        DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+  TEXT
   task local_release: [
     'db:drop',
     'db:create',


### PR DESCRIPTION
## Description

When setting log level, look to RAILS_LOG_LEVEL first, and then use `:debug` if that isn't set.

Fixes #133 

## Developer Checklist
- [ ] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [ ] All specs and linters pass (including Code Climate)
- [ ] I have followed the style of nearby code
- [ ] The build on Semaphore is successful
- [ ] I have added tests for my changes.
- [ ] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
- [ ] I have [internationalized](http://guides.rubyonrails.org/i18n.html) my
      changes
