### PR TITLE
Set APPLICATION_HOST properly for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   },
   "env": {
     "APPLICATION_HOST": {
-      "required": true
+      "required": false
     },
     "GOOGLE_MAPS_KEY": {
       "required": true

--- a/app.json
+++ b/app.json
@@ -7,6 +7,9 @@
     "GOOGLE_MAPS_KEY": {
       "required": true
     },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
     "INTERCEPT_EMAILS": {
       "required": true
     },

--- a/app.json
+++ b/app.json
@@ -4,9 +4,6 @@
     "postdeploy": "bin/rake heroku:postdeploy"
   },
   "env": {
-    "APPLICATION_HOST": {
-      "required": false
-    },
     "GOOGLE_MAPS_KEY": {
       "required": true
     },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,10 @@ Rails.application.configure do
     user_name: ENV.fetch("SMTP_USERNAME")
   }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("APPLICATION_HOST")
+    host: ENV.fetch(
+      "APPLICATION_HOST",
+      "#{ENV.fetch("HEROKU_APP_NAME")}.herokuapp.com"
+    )
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch(
       "APPLICATION_HOST",
-      "#{ENV.fetch("HEROKU_APP_NAME", '')}.herokuapp.com" # TODO: don't supply '' as a backup once this env var is generally available
+      "#{ENV.fetch("HEROKU_APP_NAME")}.herokuapp.com"
     )
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch(
       "APPLICATION_HOST",
-      "#{ENV.fetch("HEROKU_APP_NAME")}.herokuapp.com"
+      "#{ENV.fetch("HEROKU_APP_NAME", '')}.herokuapp.com"
     )
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = {
     host: ENV.fetch(
       "APPLICATION_HOST",
-      "#{ENV.fetch("HEROKU_APP_NAME", '')}.herokuapp.com"
+      "#{ENV.fetch("HEROKU_APP_NAME", '')}.herokuapp.com" # TODO: don't supply '' as a backup once this env var is generally available
     )
   }
 

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,6 +2,7 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
   desc 'Tasks to be run just once, after the first deployment'
   task postdeploy: 'db:seed' do
     Rake::Task['db:populate'].invoke if ENV['USE_SAMPLE_DATA']
+    set_application_host
   end
 
   desc 'Tasks to be run after each deployment'
@@ -28,6 +29,13 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
       Rake::Task['db:schema:load'].invoke
     else
       Rake::Task['db:migrate'].invoke
+    end
+  end
+
+  def set_application_host
+    app_name = ENV.fetch('HEROKU_APP_NAME')
+    unless %w(greensteps-staging greensteps).include?(app_name)
+      `heroku config:set APPLICATION_HOST=#{app_name}.herokuapp.com --app #{app_name}`
     end
   end
 end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,7 +2,6 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
   desc 'Tasks to be run just once, after the first deployment'
   task postdeploy: 'db:seed' do
     Rake::Task['db:populate'].invoke if ENV['USE_SAMPLE_DATA']
-    `heroku labs:enable runtime-dyno-metadata`
   end
 
   desc 'Tasks to be run after each deployment'

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,6 +2,7 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
   desc 'Tasks to be run just once, after the first deployment'
   task postdeploy: 'db:seed' do
     Rake::Task['db:populate'].invoke if ENV['USE_SAMPLE_DATA']
+    `heroku labs:enable runtime-dyno-metadata`
   end
 
   desc 'Tasks to be run after each deployment'

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -2,7 +2,6 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
   desc 'Tasks to be run just once, after the first deployment'
   task postdeploy: 'db:seed' do
     Rake::Task['db:populate'].invoke if ENV['USE_SAMPLE_DATA']
-    set_application_host
   end
 
   desc 'Tasks to be run after each deployment'
@@ -29,13 +28,6 @@ namespace :heroku do # rubocop:disable Metrics/BlockLength
       Rake::Task['db:schema:load'].invoke
     else
       Rake::Task['db:migrate'].invoke
-    end
-  end
-
-  def set_application_host
-    app_name = ENV.fetch('HEROKU_APP_NAME')
-    unless %w(greensteps-staging greensteps).include?(app_name)
-      `heroku config:set APPLICATION_HOST=#{app_name}.herokuapp.com --app #{app_name}`
     end
   end
 end


### PR DESCRIPTION
Currently, for review apps, links in emails have `greensteps-staging.herokuapp.com` as the root of the URL. This PR corrects that - they now have `greensteps-staging-pr-###.herokuapp.com` as the root.

Fixes #152 

(excuse all the junk in the timeline below I was testing out the default availability of some environment variables for Heroku review apps, to do that I need to push changes)