### PR TITLE
Fix bug in production environment config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,10 +73,8 @@ Rails.application.configure do
     user_name: ENV.fetch("SMTP_USERNAME")
   }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch(
-      "APPLICATION_HOST",
+    host: ENV["APPLICATION_HOST"] ||
       "#{ENV.fetch("HEROKU_APP_NAME")}.herokuapp.com"
-    )
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
Don't try to load the HEROKU_APP_NAME environment variable if APPLICATION_HOST is available.