### PR TITLE
Use https in links in emails

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,6 +73,7 @@ Rails.application.configure do
     user_name: ENV.fetch("SMTP_USERNAME")
   }
   config.action_mailer.default_url_options = {
+    protocol: 'https',
     host: ENV["APPLICATION_HOST"] ||
       "#{ENV.fetch("HEROKU_APP_NAME")}.herokuapp.com"
   }


### PR DESCRIPTION
## Description

Before links in emails weren't using https, so when the user clicks on them the browser reports them as insecure. Now they use https and all is well.

Fixes #160 

## Developer Checklist
- [x] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [x] All specs and linters pass (including Code Climate)
- [x] I have followed the style of nearby code
- [x] The build on Semaphore is successful
- [x] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
