### PR TITLE
Conditional root paths

### DIFF
--- a/app/assets/stylesheets/layout/_navigation.scss
+++ b/app/assets/stylesheets/layout/_navigation.scss
@@ -11,6 +11,7 @@
 
   .logo {
     align-items: baseline;
+    color: $primary-text-light;
     display: flex;
     font-family: $logo-font-family;
     font-size: modular-scale(3);

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,8 +1,8 @@
 <nav id="app_bar" data-turbolinks-permanent>
-  <div class="logo">
+  <%= link_to root_path, class: 'logo' do %>
     <%= image_tag 'tree.svg' %>
     <span>Green Steps</span>
-  </div>
+  <% end %>
 
   <%= fa_icon('navicon', class: 'menu_toggler') if user_signed_in? %>
 </nav>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -10,11 +10,11 @@
 <% if user_signed_in? %>
   <div id="nav_drawer_container" data-turbolinks-permanent>
     <nav id="nav_drawer">
+      <% if current_user.has_role?(:admin) %>
+        <%= link_to t('.user_dashboard'), dashboard_path %>
+      <% end %>
       <%= link_to 'Profile', edit_user_registration_path %>
       <%= button_to 'Log out', destroy_user_session_path, method: :delete %>
-      <% if current_user.has_role?(:admin) %>
-        <%= link_to 'Admin Dashboard', admins_dashboard_path %>
-      <% end %>
     </nav>
   </div>
 <% end %>

--- a/config/locales/views/shared/navigation/en.yml
+++ b/config/locales/views/shared/navigation/en.yml
@@ -3,4 +3,4 @@ en:
     navigation:
       edit_account: "Profile"
       destroy_session: "Log out"
-      admin_dashboard: "Admin Dashboard"
+      user_dashboard: "User Dashboard"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,5 @@ Rails.application.routes.draw do
     end
   end
 
-  get 'dashboard', to: 'dashboards#show', as: :user_root
-
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,14 @@
 Rails.application.routes.draw do
   resource :dashboard, only: [:show]
 
+  authenticated :user, lambda { |user| user.has_role?(:admin) } do
+    root to: 'admins/dashboards#show'
+  end
+
+  authenticated :user do
+    root to: 'dashboards#show'
+  end
+
   root to: 'welcome#index'
   get 'welcome/index'
 
@@ -27,4 +35,3 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
-

--- a/spec/controllers/admins/prizes_controller_spec.rb
+++ b/spec/controllers/admins/prizes_controller_spec.rb
@@ -19,7 +19,10 @@ RSpec.describe Admins::PrizesController, type: :controller do
         sign_in create(:admin)
         prize = create(:prize)
 
-        put :update, params: { id: prize.id, prize: attributes_for(:prize, :invalid) }
+        put :update, params: {
+          id: prize.id,
+          prize: attributes_for(:prize, :invalid)
+        }
 
         expect(response).to render_template(:edit)
       end

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -25,4 +25,13 @@ RSpec.describe 'Navigation' do
 
     expect(page).to show :nav_drawer
   end
+
+  scenario 'User clicks on the logo and is taken to the root path' do
+    create_and_login_user
+
+    visit new_deed_path
+    app_bar.click_on_logo
+
+    expect(page).to have_current_path root_path
+  end
 end

--- a/spec/features/root_route_specs.rb
+++ b/spec/features/root_route_specs.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Root route for various situations', type: :feature do
+  scenario 'for an admin, the root route shows the admin dashboard' do
+    create_and_login_admin
+
+    visit root_path
+
+    expect(page).to show :admin_dashboard
+  end
+
+  scenario 'for a regular user, the root route shows the regular dashboard' do
+    create_and_login_user
+
+    visit root_path
+
+    expect(page).to show :dashboard
+  end
+
+  scenario 'for a visitor, the root route shows the welcome page' do
+    visit root_path
+
+    expect(page).to show :welcome_page
+  end
+end

--- a/spec/features/users/sessions_spec.rb
+++ b/spec/features/users/sessions_spec.rb
@@ -12,6 +12,16 @@ RSpec.describe 'User Sessions', type: :feature do
     expect(page).to show :dashboard
   end
 
+  scenario 'Admin signs in' do
+    admin = create :admin
+
+    visit root_path
+    welcome_page.open_log_in_form
+    log_in_form.fill_and_submit_for admin
+
+    expect(page).to show :admin_dashboard
+  end
+
   scenario 'User cannot login after deleting their account' do
     user = create :user, :soft_deleted
 

--- a/spec/models/station_spec.rb
+++ b/spec/models/station_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Station, type: :model do
     context 'when there is an associated address record' do
       it 'delegates to address.to_sentence' do
         create :station_form, street: '101 Main St', city: 'Boulder',
-               state: 'CO', zip: '80304'
+                              state: 'CO', zip: '80304'
         station = Station.first
 
         expect(station.street_address).to eq '101 Main St, Boulder, CO 80304'
@@ -76,7 +76,7 @@ RSpec.describe Station, type: :model do
     context 'when there is not an associated address' do
       it 'prints the latitude and longitude' do
         create :station_form, :no_street_address, latitude: 10.0,
-               longitude: 20.0
+                                                  longitude: 20.0
         station = Station.first
 
         expect(station.street_address).to eq '10.0, 20.0'

--- a/spec/page_objects/app_bar.rb
+++ b/spec/page_objects/app_bar.rb
@@ -10,6 +10,10 @@ module PageObjects
       wait_for_animations
     end
 
+    def click_on_logo
+      find('.logo').click
+    end
+
     def selector
       '#app_bar'
     end

--- a/spec/page_objects/nav_drawer.rb
+++ b/spec/page_objects/nav_drawer.rb
@@ -1,9 +1,5 @@
 module PageObjects
   class NavDrawer < Base
-    def open_admin_dashboard
-      click_on t('shared.navigation.admin_dashboard')
-    end
-
     def edit_account_settings
       click_on t('shared.navigation.edit_account')
     end

--- a/spec/views/shared/_navigation.html.erb_spec.rb
+++ b/spec/views/shared/_navigation.html.erb_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'shared/_navigation' do
       render template: 'shared/_navigation'
     end
 
-    it { should_not have_link t('shared.navigation.admin_dashboard') }
+    it { should_not have_link t('shared.navigation.user_dashboard') }
   end
 
   context 'for a logged in admin' do
@@ -16,6 +16,6 @@ RSpec.describe 'shared/_navigation' do
       render template: 'shared/_navigation'
     end
 
-    it { should have_link t('shared.navigation.admin_dashboard') }
+    it { should have_link t('shared.navigation.user_dashboard') }
   end
 end


### PR DESCRIPTION
## Description
- the logo in the app bar now links to the root path
- the root path now depends on the user - for admins, it is the admin dashboard, for regular users, it is the regular dashboard, and for visitors, it is the welcome page
- for admins, the link to the admin dashboard was removed because now they can access this by clicking on the logo; instead, they now have a link to the user dashboard

Fixes #169
Fixes #170

## Developer Checklist
*You can mark items off by replacing `[ ]` with `[x]` or in the rendered
markdown, you can simply check the checkbox.*
- [ ] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [ ] All specs and linters pass (including Code Climate)
- [ ] I have followed the style of nearby code
- [ ] The build on Semaphore is successful
- [ ] I have added tests for my changes.
- [ ] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
- [ ] I have [internationalized](http://guides.rubyonrails.org/i18n.html) my
      changes
