### PR TITLE
Fix station form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,7 @@ mkmf.log
 # Ignore locally compiled assets
 public/assets
 
+# Ignore ActiveStorage files from development environment
+storage
+
 node_modules

--- a/app/assets/javascripts/admins/stations.coffee
+++ b/app/assets/javascripts/admins/stations.coffee
@@ -1,3 +1,8 @@
 $(document).on 'turbolinks:load', ->
   $('#address_or_coordinates_toggler').on 'click', ->
     $(document).find('#street_address_fields, #coordinate_fields').toggle()
+
+  $('form[id$="station_form"]').on 'submit', (event) ->
+    form = $(event.target)
+    inactiveFieldset = form.find('fieldset:hidden')
+    inactiveFieldset.remove()

--- a/app/assets/stylesheets/pages/admins/_station.scss
+++ b/app/assets/stylesheets/pages/admins/_station.scss
@@ -1,8 +1,20 @@
 .admins-stations.new, .admins-stations.create {
   max-width: 31em;
 
+  .or {
+    background-color: $base-background-color;
+    border-radius: 50%;
+    font-size: modular-scale(-1);
+    padding: $tiny-spacing;
+    position: absolute;
+    right: 50%;
+    top: 13.75%;
+    z-index: 1;
+  }
+
   #address_or_coordinates_toggler {
     @include radio-button-group;
+    position: relative;
   }
 
   #coordinate_fields {

--- a/app/forms/station_form.rb
+++ b/app/forms/station_form.rb
@@ -2,13 +2,17 @@ class StationForm < ApplicationForm
   attr_accessor :name, :street, :city, :state, :zip, :latitude, :longitude
 
   validates_models :station, :address, :coordinate_pair
+  validate :at_least_one_of_address_and_coords_present
+  validate :only_one_of_address_and_coords_present
 
-  validate do
-    unless address.present? || coordinate_pair.present?
-      errors[:base] << <<~TEXT
-        A station needs either a street address or a latitude and longitude
-      TEXT
-    end
+  def at_least_one_of_address_and_coords_present
+    return if address.present? || coordinate_pair.present?
+    errors.add(:base, :at_least_one_addr_coords)
+  end
+
+  def only_one_of_address_and_coords_present
+    return unless address.present? && coordinate_pair.present?
+    errors.add(:base, :only_one_addr_coords)
   end
 
   def save!

--- a/app/views/admins/stations/_form.html.erb
+++ b/app/views/admins/stations/_form.html.erb
@@ -8,6 +8,9 @@
     <button type="button" id="use_address" class="selected">
       <%= t '.address' %>
     </button>
+    <div class="or">
+      <%= t '.or' %>
+    </div>
     <button type="button" id="use_coordinates">
       <%= t '.coordinates' %>
     </button>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,3 +49,11 @@ en:
       create: "Save"
       update: "Save"
     cancel: "Cancel"
+  activemodel:
+    errors:
+      models:
+        station_form:
+          attributes:
+            base:
+              only_one_addr_coords: "A station can't have both an address and coordinates. If you provide an addresss, we'll look up the coordinates."
+              at_least_one_addr_coords: "A station needs either a street address or a latitude and longitude."

--- a/config/locales/views/admins/stations/en.yml
+++ b/config/locales/views/admins/stations/en.yml
@@ -8,3 +8,4 @@ en:
       form:
         address: "Address"
         coordinates: "Coordinates"
+        or: "OR"

--- a/spec/factories/station_form.rb
+++ b/spec/factories/station_form.rb
@@ -8,7 +8,10 @@ FactoryBot.define do
 
     trait :with_coords_only do
       no_street_address
+      with_coords
+    end
 
+    trait :with_coords do
       latitude { Faker::Number.between(34.952750, 35.223899).round(6) }
       longitude { Faker::Number.between(-85.550085, -85.031483).round(6) }
     end

--- a/spec/features/admins/stations_spec.rb
+++ b/spec/features/admins/stations_spec.rb
@@ -3,9 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Stations management', type: :feature do
   scenario 'Admin adds a new station with an address', :js,
            :with_active_job_test_adapter do
-    stubbed_login_as create(:admin)
+    create_and_login_admin follow_to_default_path: true
 
-    visit admins_dashboard_path
     admin_dashboard.add_station
     station_form.name = 'Downtown - Central'
     station_form.street = '121 Main Street'
@@ -20,10 +19,9 @@ RSpec.describe 'Stations management', type: :feature do
   end
 
   scenario 'Admin adds a new address with a lat and long', :js do
-    stubbed_login_as create(:admin)
+    create_and_login_admin
 
-    visit admins_dashboard_path
-    admin_dashboard.add_station
+    visit new_admins_station_path
     station_form.name = 'Bushtown'
     station_form.toggle_addr_latlon
     station_form.latitude = 35.042039
@@ -36,10 +34,9 @@ RSpec.describe 'Stations management', type: :feature do
 
   scenario 'Admin can toggle back and forth between street address and '\
     'coordinate fields', :js do
-    stubbed_login_as create(:admin)
+    create_and_login_admin
+    visit new_admins_station_path
 
-    visit admins_dashboard_path
-    admin_dashboard.add_station
     expect(page).to_not have_content 'Latitude'
 
     station_form.toggle_addr_latlon

--- a/spec/features/admins/stations_spec.rb
+++ b/spec/features/admins/stations_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe 'Stations management', type: :feature do
     station_form.toggle_addr_latlon
     expect(page).to have_content 'Latitude'
   end
+
+  scenario 'Admin starts adding an address then switches to coordinates', :js do
+    create_and_login_admin
+    visit new_admins_station_path
+
+    station_form.name = 'Bushtown'
+    station_form.street = '1254 E 3rd St'
+    station_form.city = 'Chattanooga'
+    station_form.select_state 'Tennessee'
+    station_form.zip = '37404'
+    station_form.toggle_addr_latlon
+    station_form.latitude = 35.042039
+    station_form.longitude = -85.283085
+    station_form.submit
+
+    station = Station.first
+    expect(station.address).to_not be_present
+    expect(station.coordinate_pair).to be_present
+  end
 end

--- a/spec/forms/station_form_spec.rb
+++ b/spec/forms/station_form_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe StationForm, type: :form do
     end
   end
 
+  context 'when given both an address and coordinates' do
+    it 'is not valid' do
+      station_form = build :station_form, :with_coords
+
+      expect(station_form).to be_invalid
+    end
+  end
+
   describe '#save' do
     it 'should return a truthy value if the records were saved' do
       station_form = build :station_form


### PR DESCRIPTION
## Description
Station form should accept either an address or coordinates, not both.

## Developer Checklist
- [x] I have read and followed the [contribution guidelines](
      https://github.com/crawfoal/greensteps/blob/master/CONTRIBUTING.md).
- [x] All specs and linters pass (including Code Climate)
- [x] I have followed the style of nearby code
- [x] The build on Semaphore is successful
- [x] I have added tests for my changes.
- [x] I have gone through my changes by hand, either in the browser or terminal,
      which ever makes sense
- [x] I have [internationalized](http://guides.rubyonrails.org/i18n.html) my
      changes
